### PR TITLE
MADO format code

### DIFF
--- a/input/ignoreWarnings.txt
+++ b/input/ignoreWarnings.txt
@@ -4,3 +4,4 @@
 WARNING: ValueSet/formatcode: ValueSet.compose.include[2].system: URL value 'http://dicom.nema.org/resources/ontology/DCMUID' does not resolve
 WARNING: ValueSet/formatcode: ValueSet.compose.include[2]: Unknown System 'http://dicom.nema.org/resources/ontology/DCMUID' specified, so Concepts and Filters can't be checked (Details: A definition for CodeSystem 'http://dicom.nema.org/resources/ontology/DCMUID' could not be found, so the code cannot be validated)
 WARNING: ValueSet.where(id = 'formatcode'): Error from http://tx.fhir.org/r4: Unable to provide support for code system http://dicom.nema.org/resources/ontology/DCMUID
+Error from https://tx.fhir.org/r4: Error: A definition for CodeSystem 'http://dicom.nema.org/resources/ontology/DCMUID' could not be found, so the value set cannot be expanded

--- a/input/implementationguide-IHE.FormatCode.xml
+++ b/input/implementationguide-IHE.FormatCode.xml
@@ -16,7 +16,7 @@ ImplementationGuide for IHE Format Code vocabulary.
 	<title value="IHE FormatCode Vocabulary" />
 	<status value="active" />
 	<experimental value="false" />
-    <date value="2024-02-25" /> 
+    <date value="2026-02-25" /> 
 	<publisher value="Integrating the Healthcare Enterprise (IHE)" />
 	<contact>
 		<name value="IHE" />

--- a/input/implementationguide-IHE.FormatCode.xml
+++ b/input/implementationguide-IHE.FormatCode.xml
@@ -11,12 +11,12 @@ ImplementationGuide for IHE Format Code vocabulary.
 		<valueDate value="2025-04-28"/>
 	</extension>
 	<url value="https://profiles.ihe.net/fhir/ihe.formatcode.fhir/ImplementationGuide/ihe.formatcode.fhir" />
-	<version value="1.4.1-current" />
+	<version value="1.5.1-current" />
 	<name value="IHE_FORMATCODE" />
 	<title value="IHE FormatCode Vocabulary" />
 	<status value="active" />
 	<experimental value="false" />
-<!--	<date value="2024-05-23" />  -->
+    <date value="2024-02-25" /> 
 	<publisher value="Integrating the Healthcare Enterprise (IHE)" />
 	<contact>
 		<name value="IHE" />

--- a/input/resources/Bundle-history-IHE-formatcode.codesystem.xml
+++ b/input/resources/Bundle-history-IHE-formatcode.codesystem.xml
@@ -615,4 +615,55 @@
 			</Provenance>
 		</resource>
 	</entry>
+	<entry>
+		<fullUrl value="urn:oid:1.3.6.1.4.1.19376.1.2.3.1.20260225"/>
+		<resource>
+			<Provenance>
+				<id value="formatcode-provenance-20260225"/>
+				<target>
+					<reference value="http://ihe.net/fhir/ihe.formatcode.fhir/CodeSystem/formatcode"/>
+					<type value="CodeSystem"/>
+				</target>
+				<occurredPeriod>
+					<end value="2026-02-25"/>
+				</occurredPeriod>
+				<recorded value="2026-02-25T23:00:00.0000Z"/>
+				<reason>
+					<coding>
+						<system value="http://terminology.hl7.org/CodeSystem/v3-ActReason"/>
+						<code value="METAMGT"/>
+					</coding>
+					<text value="MADO format code (CP#35)."/>
+				</reason>
+				<activity>
+					<coding>
+						<system value="http://terminology.hl7.org/CodeSystem/v3-DataOperation"/>
+						<code value="CREATE"/>
+					</coding>
+				</activity>
+				<agent>
+					<type>
+						<coding>
+							<system value="http://terminology.hl7.org/CodeSystem/provenance-participant-type"/>
+							<code value="author"/>
+						</coding>
+					</type>
+					<who>
+						<display value="Wim Corbijn"/>
+					</who>
+				</agent>
+				<agent>
+					<type>
+						<coding>
+							<system value="http://terminology.hl7.org/CodeSystem/provenance-participant-type"/>
+							<code value="custodian"/>
+						</coding>
+					</type>
+					<who>
+						<display value="IHE RAD-Radiology Domain"/>
+					</who>
+				</agent>
+			</Provenance>
+		</resource>
+	</entry>
 </Bundle> 

--- a/input/resources/codesystem-formatcode.xml
+++ b/input/resources/codesystem-formatcode.xml
@@ -631,6 +631,7 @@ The actual list of codes is intended to be extensible.
 			<code value="notSelectable" />
 			<valueBoolean value="true" />
 		</property>
+
 		<concept>
 			<code value="urn:ihe:rad:TEXT"/>
 			<display value="RAD TEXT"/>
@@ -655,6 +656,16 @@ The actual list of codes is intended to be extensible.
 			<code value="urn:ihe:rad:CDA:ImagingReportStructuredHeadings:2013"/>
 			<display value="RAD CDA"/>
 			<definition value="Radiology XDS-I Structured CDA"/>
+			<property>
+				<code value="status"/>
+				<valueCode value="active"/>
+			</property>
+		</concept>
+
+		<concept>
+			<code value="urn:ihe:rad:MADO:fhir-manifest:2026"/>
+			<display value="RAD MADO"/>
+			<definition value="MADO Imaging Study Manifest in FHIR Format"/>
 			<property>
 				<code value="status"/>
 				<valueCode value="active"/>


### PR DESCRIPTION
Here is what IHE RAD needs for the CREATION of a new format code:

Under 
> urn:ihe:rad | RAD Domain | Ontology group for all RAD defined FormatCodes 

Create
>  urn:ihe:rad:MADO:fhir-manifest :2026 | RAD MADO | MADO Imaging Study Manifest in FHIR Format | active 

This request is submitted by/on behalf of the IHE Radiology Technical Committee. 
The Format code needs to be included in the Trial Implementation version of the MADO Profile to be issued sometime in February.

## ✅ Checks
- [X ] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ X] All the tests have passed
- [ ] I have selected a committee co-chair to review the PR

## ℹ Additional Information
Publisher update introduced an error of what previously was an warning. I've added it to the ignoreWarmings.txt